### PR TITLE
Refine application lifecycle and bootstrap ImGui overlay

### DIFF
--- a/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
@@ -1,17 +1,23 @@
 #include "Core/Application.h"
-#include "SDL3/SDL.h"
-#include "string"
-#include "string_view"
-#include "utility"
+
+#include <SDL3/SDL.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+
 #include "Core/Logger.h"
 #include "Core/Timer.h"
 #include "Core/Window.h"
 #include "Game/Scene.h"
 #include "Game/SceneManager.h"
-#include "Game/Test/TestScene.h"
 #include "Graphics/Renderer.h"
 #include "Input/Input.h"
 #include "Input/InputManager.h"
+
+#include "imgui.h"
+#include "imgui_impl_sdl3.h"
+#include "imgui_impl_sdlrenderer3.h"
 
 namespace Engine::Core
 {
@@ -39,15 +45,9 @@ namespace Engine::Core
         if (!InitializeSDL())
             return false;
 
-        if (!CreateWindow())
+        if (!CreateWindow() || !CreateRenderer() || !InitializeImGui())
         {
-            ShutdownSDL();
-            return false;
-        }
-
-        if (!CreateRenderer())
-        {
-            ShutdownSDL();
+            Shutdown();
             return false;
         }
 
@@ -64,11 +64,19 @@ namespace Engine::Core
 
         while (running_)
         {
-            timer_->Tick();
-            const float dt = timer_->GetDeltaTime();
+            if (timer_)
+            {
+                timer_->Tick();
+                lastDeltaTime_ = timer_->GetDeltaTime();
+            }
+            else
+            {
+                lastDeltaTime_ = 0.0f;
+            }
 
             ProcessEvents();
-            Update(dt);
+            BeginFrame();
+            Update(lastDeltaTime_);
             Render();
         }
     }
@@ -81,23 +89,48 @@ namespace Engine::Core
         ShutdownSDL();
     }
 
-    void Application::ProcessEvents() {
-        SDL_Event event;
+    void Application::ProcessEvents()
+    {
+        SDL_Event event{};
         while (SDL_PollEvent(&event))
         {
+            if (imguiInitialized_)
+                ImGui_ImplSDL3_ProcessEvent(&event);
+
             input_->ProcessEvent(event);
 
             if (inputManager_)
                 inputManager_->ProcessEvent(event);
+
             if (sceneManager_)
             {
-                if (auto* scene = sceneManager_->GetScene())
+                if (Game::Scene* scene = sceneManager_->GetScene())
                     scene->HandleEvent(event);
             }
+
+            if (event.type == SDL_EVENT_QUIT)
+                running_ = false;
         }
 
         if (input_->IsQuitRequested() || input_->IsKeyDown(SDLK_ESCAPE))
             running_ = false;
+    }
+
+    void Application::BeginFrame()
+    {
+        if (!imguiInitialized_)
+            return;
+
+        if (!ImGui::GetCurrentContext())
+        {
+            LOG_WARNING("ImGui context not available; disabling ImGui frame generation.");
+            imguiInitialized_ = false;
+            return;
+        }
+
+        ImGui_ImplSDLRenderer3_NewFrame();
+        ImGui_ImplSDL3_NewFrame();
+        ImGui::NewFrame();
     }
 
     void Application::Update(float deltaTime)
@@ -118,15 +151,10 @@ namespace Engine::Core
             return;
 
         renderer_->Clear(config_.clearColor);
-        Game::Scene* activeScene = nullptr;
-        
-        if (sceneManager_)
-        {
-            activeScene = sceneManager_->GetScene();
-            
-            if (activeScene)
-                activeScene->Render(*renderer_);
-        }
+
+        Game::Scene* activeScene = sceneManager_ ? sceneManager_->GetScene() : nullptr;
+        if (activeScene)
+            activeScene->Render(*renderer_);
 
         if (timer_)
             SDL_RenderDebugTextFormat(renderer_->GetSDLRenderer(), 10, 10, "FPS: %.0f", timer_->GetFPS());
@@ -134,10 +162,46 @@ namespace Engine::Core
         if (activeScene)
         {
             const std::string_view sceneName = activeScene->Name();
-            SDL_RenderDebugTextFormat(renderer_->GetSDLRenderer(), 10, 30, "Scene: %.*s", static_cast<int>(sceneName.size()), sceneName.data());
+            SDL_RenderDebugTextFormat(
+                renderer_->GetSDLRenderer(),
+                10,
+                30,
+                "Scene: %.*s",
+                static_cast<int>(sceneName.size()),
+                sceneName.data());
         }
 
+        RenderGui(activeScene);
         renderer_->Present();
+    }
+
+    void Application::RenderGui(Game::Scene* activeScene)
+    {
+        if (!imguiInitialized_)
+            return;
+
+        if (!ImGui::GetCurrentContext())
+        {
+            LOG_WARNING("ImGui context not available; skipping ImGui rendering.");
+            imguiInitialized_ = false;
+            return;
+        }
+
+        ImGui::Begin("Engine Stats");
+        ImGui::Text("FPS: %.1f", timer_ ? timer_->GetFPS() : 0.0f);
+        ImGui::Text("Delta Time: %.3f ms", lastDeltaTime_ * 1000.0f);
+
+        if (activeScene)
+        {
+            const std::string_view sceneName = activeScene->Name();
+            ImGui::Separator();
+            ImGui::Text("Scene: %.*s", static_cast<int>(sceneName.size()), sceneName.data());
+        }
+
+        ImGui::End();
+
+        ImGui::Render();
+        ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), renderer_->GetSDLRenderer());
     }
 
     bool Application::InitializeSDL()
@@ -151,7 +215,7 @@ namespace Engine::Core
             kDefaultAppId
         );
 
-        if (!SDL_Init(SDL_INIT_VIDEO))
+        if (SDL_Init(SDL_INIT_VIDEO) != 0)
         {
             LOG_ERROR(std::string{"Couldn't initialize SDL: "} + SDL_GetError());
             return false;
@@ -185,7 +249,48 @@ namespace Engine::Core
             window_.reset();
             return false;
         }
-        
+
+        return true;
+    }
+
+    bool Application::InitializeImGui()
+    {
+        if (imguiInitialized_)
+            return true;
+
+        if (!window_ || !renderer_)
+            return false;
+
+        IMGUI_CHECKVERSION();
+        ImGui::CreateContext();
+        ImGuiIO& io = ImGui::GetIO();
+        io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+        ImGui::StyleColorsDark();
+
+        if (!ImGui_ImplSDL3_InitForSDLRenderer(window_->GetSDLWindow(), renderer_->GetSDLRenderer()))
+        {
+            const char* error = SDL_GetError();
+            if (error && *error)
+                LOG_ERROR(std::string{"Failed to initialize ImGui SDL3 backend: "} + error);
+            else
+                LOG_ERROR("Failed to initialize ImGui SDL3 backend.");
+            ImGui::DestroyContext();
+            return false;
+        }
+
+        if (!ImGui_ImplSDLRenderer3_Init(renderer_->GetSDLRenderer()))
+        {
+            const char* error = SDL_GetError();
+            if (error && *error)
+                LOG_ERROR(std::string{"Failed to initialize ImGui SDL renderer backend: "} + error);
+            else
+                LOG_ERROR("Failed to initialize ImGui SDL renderer backend.");
+            ImGui_ImplSDL3_Shutdown();
+            ImGui::DestroyContext();
+            return false;
+        }
+
+        imguiInitialized_ = true;
         return true;
     }
 
@@ -217,8 +322,10 @@ namespace Engine::Core
             sceneManager_->SetScene(nullptr);
 
         sceneManager_.reset();
+        inputManager_.reset();
         input_.reset();
         timer_.reset();
+        ShutdownImGui();
         renderer_.reset();
         window_.reset();
     }
@@ -230,5 +337,19 @@ namespace Engine::Core
             SDL_Quit();
             sdlInitialized_ = false;
         }
+    }
+
+    void Application::ShutdownImGui() noexcept
+    {
+        if (!imguiInitialized_)
+            return;
+
+        ImGui_ImplSDLRenderer3_Shutdown();
+        ImGui_ImplSDL3_Shutdown();
+
+        if (ImGuiContext* context = ImGui::GetCurrentContext())
+            ImGui::DestroyContext(context);
+
+        imguiInitialized_ = false;
     }
 }

--- a/GameEngine/GameEngine/Engine/Source/Core/Public/Core/Application.h
+++ b/GameEngine/GameEngine/Engine/Source/Core/Public/Core/Application.h
@@ -10,7 +10,7 @@ namespace Engine
 {
 
     namespace Graphics { class Renderer; }
-    namespace Game     { class SceneManager; }
+    namespace Game     { class Scene; class SceneManager; }
     namespace Input    { class InputManager; class Input; }
     namespace Core     { class Window; class Timer; }
 
@@ -49,16 +49,22 @@ namespace Engine
                 bool InitializeSDL();
                 bool CreateWindow();
                 bool CreateRenderer();
+                bool InitializeImGui();
                 void InitializeSubsystems();
                 void ShutdownSubsystems() noexcept;
                 void ShutdownSDL() noexcept;
+                void ShutdownImGui() noexcept;
                 void ProcessEvents();
+                void BeginFrame();
                 void Update(float deltaTime);
                 void Render();
+                void RenderGui(Game::Scene* activeScene);
 
                 Config config_{};
                 bool running_{false};
                 bool sdlInitialized_{false};
+                bool imguiInitialized_{false};
+                float lastDeltaTime_{0.0f};
 
                 std::unique_ptr<Window> window_;
                 std::unique_ptr<Graphics::Renderer> renderer_;

--- a/GameEngine/GameEngine/Engine/Source/Graphics/Private/Graphics/Renderer.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Graphics/Private/Graphics/Renderer.cpp
@@ -1,7 +1,6 @@
 #include "Graphics/Renderer.h"
-#include "string"
+#include <string>
 #include "Core/Logger.h"
-#include "imgui.h"
 
 namespace Engine::Graphics
 {


### PR DESCRIPTION
## Summary
- streamline the application lifecycle to centralize initialization, frame handling, and shutdown paths
- add initial Dear ImGui setup, frame processing, and a simple stats overlay rendered each frame
- fix the SDL initialization guard and clean up subsystem shutdown, including removing the unused ImGui include from the renderer

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b417c31483308cc37c74cba548a4