### PR TITLE
Add ImGui compilation units to project build

### DIFF
--- a/GameEngine/GameEngine/GameEngine.vcxproj
+++ b/GameEngine/GameEngine/GameEngine.vcxproj
@@ -1629,6 +1629,13 @@
     <ClCompile Include="Exemple\main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Libs\ImGui\imgui.cpp" />
+    <ClCompile Include="..\Libs\ImGui\imgui_demo.cpp" />
+    <ClCompile Include="..\Libs\ImGui\imgui_draw.cpp" />
+    <ClCompile Include="..\Libs\ImGui\imgui_tables.cpp" />
+    <ClCompile Include="..\Libs\ImGui\imgui_widgets.cpp" />
+    <ClCompile Include="..\Libs\ImGui\backends\imgui_impl_sdl3.cpp" />
+    <ClCompile Include="..\Libs\ImGui\backends\imgui_impl_sdlrenderer3.cpp" />
     <ClInclude Include="Engine\Source\Core\Public\Core\Application.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Engine.h" />
     <ClInclude Include="Engine\Source\Core\Public\Core\Logger.h" />

--- a/GameEngine/GameEngine/GameEngine.vcxproj.filters
+++ b/GameEngine/GameEngine/GameEngine.vcxproj.filters
@@ -100,6 +100,12 @@
     <Filter Include="Source\Math\Public\Math">
       <UniqueIdentifier>{9BEEBD80-A6AE-4EAE-B888-D17115633F8D}</UniqueIdentifier>
     </Filter>
+    <Filter Include="External">
+      <UniqueIdentifier>{8C922B88-A7B2-4A38-8F45-1A3B65FAF06E}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="External\ImGui">
+      <UniqueIdentifier>{BB6CD2E5-9AFE-438B-8CE7-6A861A7C7E7F}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Resource Files">
       <UniqueIdentifier>{DFC89BCC-BEB7-40C5-98CC-315E5A204203}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
@@ -171,6 +177,27 @@
     </ClCompile>
     <ClCompile Include="Exemple\main.cpp">
       <Filter>Exemple</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\imgui.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\imgui_demo.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\imgui_draw.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\imgui_tables.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\imgui_widgets.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\backends\imgui_impl_sdl3.cpp">
+      <Filter>External\ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Libs\ImGui\backends\imgui_impl_sdlrenderer3.cpp">
+      <Filter>External\ImGui</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add the Dear ImGui core and SDL3 backend sources to the GameEngine project so the linker can resolve ImGui symbols
- group the ImGui sources under a dedicated External/ImGui filter for easier browsing in the solution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7b8d577588330bc49919e1f1478eb