### PR TITLE
Remove JSON scene serialization support

### DIFF
--- a/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Actor.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Actor.cpp
@@ -1,11 +1,16 @@
 #include "Game/Actor.h"
 #include "Game/Components/Component.h"
 
+#include <utility>
+
 
 namespace Engine::Game
 {
     Actor::Actor(const Math::Transform& transform)
-        : transform_(transform) {}
+        : Object("Actor", transform) {}
+
+    Actor::Actor(std::string name, const Math::Transform& transform)
+        : Object(std::move(name), transform) {}
 
     Actor::~Actor() = default;
 

--- a/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Object.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Object.cpp
@@ -1,0 +1,146 @@
+#include "Game/Object.h"
+
+#include <array>
+#include <cstdint>
+#include <iomanip>
+#include <istream>
+#include <ostream>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace Engine::Game
+{
+    namespace
+    {
+        constexpr std::uint32_t kBinaryFormatVersion = 1;
+    }
+
+    Object::Object()
+        : Object("Object")
+    {
+    }
+
+    Object::Object(std::string name)
+        : uuid_(GenerateUUID()), name_(std::move(name))
+    {
+    }
+
+    Object::Object(std::string name, const Math::Transform& transform)
+        : uuid_(GenerateUUID()), name_(std::move(name)), transform_(transform)
+    {
+    }
+
+    void Object::SetUUID(std::string uuid)
+    {
+        uuid_ = std::move(uuid);
+    }
+
+    void Object::SetName(std::string name)
+    {
+        name_ = std::move(name);
+    }
+
+    std::string_view Object::GetTypeName() const noexcept
+    {
+        return "Object";
+    }
+
+    void Object::SerializeBinary(std::ostream& stream) const
+    {
+        WritePrimitive(stream, kBinaryFormatVersion);
+        WriteString(stream, uuid_);
+        WriteString(stream, name_);
+        SerializeTransform(stream);
+        SerializeBinaryImpl(stream);
+    }
+
+    void Object::DeserializeBinary(std::istream& stream)
+    {
+        std::uint32_t version = 0;
+        ReadPrimitive(stream, version);
+        if (version != kBinaryFormatVersion)
+            throw std::runtime_error("Unsupported object binary version.");
+
+        uuid_ = ReadString(stream);
+        name_ = ReadString(stream);
+        DeserializeTransform(stream);
+        DeserializeBinaryImpl(stream);
+    }
+
+    void Object::WriteString(std::ostream& stream, std::string_view value)
+    {
+        const auto length = static_cast<std::uint32_t>(value.size());
+        WritePrimitive(stream, length);
+        stream.write(value.data(), static_cast<std::streamsize>(length));
+    }
+
+    std::string Object::ReadString(std::istream& stream)
+    {
+        std::uint32_t length = 0;
+        ReadPrimitive(stream, length);
+        std::string result(length, '\0');
+        stream.read(result.data(), static_cast<std::streamsize>(length));
+        if (!stream)
+            throw std::runtime_error("Failed to read string from stream.");
+        return result;
+    }
+
+    std::string Object::GenerateUUID()
+    {
+        std::array<std::uint8_t, 16> data{};
+
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<int> dist(0, 255);
+
+        for (auto& byte : data)
+            byte = static_cast<std::uint8_t>(dist(gen));
+
+        // Set UUID version (4) and variant (RFC 4122)
+        data[6] = static_cast<std::uint8_t>((data[6] & 0x0F) | 0x40);
+        data[8] = static_cast<std::uint8_t>((data[8] & 0x3F) | 0x80);
+
+        std::ostringstream oss;
+        oss << std::hex << std::setfill('0');
+
+        for (std::size_t i = 0; i < data.size(); ++i)
+        {
+            oss << std::setw(2) << static_cast<int>(data[i]);
+            if (i == 3 || i == 5 || i == 7 || i == 9)
+                oss << '-';
+        }
+
+        return oss.str();
+    }
+
+    void Object::SerializeTransform(std::ostream& stream) const
+    {
+        WritePrimitive(stream, transform_.position.x);
+        WritePrimitive(stream, transform_.position.y);
+        WritePrimitive(stream, transform_.position.z);
+
+        WritePrimitive(stream, transform_.rotation.pitch);
+        WritePrimitive(stream, transform_.rotation.yaw);
+        WritePrimitive(stream, transform_.rotation.roll);
+
+        WritePrimitive(stream, transform_.scale.x);
+        WritePrimitive(stream, transform_.scale.y);
+        WritePrimitive(stream, transform_.scale.z);
+    }
+
+    void Object::DeserializeTransform(std::istream& stream)
+    {
+        ReadPrimitive(stream, transform_.position.x);
+        ReadPrimitive(stream, transform_.position.y);
+        ReadPrimitive(stream, transform_.position.z);
+
+        ReadPrimitive(stream, transform_.rotation.pitch);
+        ReadPrimitive(stream, transform_.rotation.yaw);
+        ReadPrimitive(stream, transform_.rotation.roll);
+
+        ReadPrimitive(stream, transform_.scale.x);
+        ReadPrimitive(stream, transform_.scale.y);
+        ReadPrimitive(stream, transform_.scale.z);
+    }
+}

--- a/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Scene.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Scene.cpp
@@ -23,6 +23,16 @@ namespace Engine::Game
         actors_.push_back(std::move(actor));
     }
 
+    void Scene::ClearActors() noexcept
+    {
+        actors_.clear();
+    }
+
+    void Scene::Rename(std::string name)
+    {
+        name_ = std::move(name);
+    }
+
     void Scene::SetName(std::string name)
     {
         name_ = std::move(name);

--- a/GameEngine/GameEngine/Engine/Source/Game/Private/Game/SceneSerializer.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Game/Private/Game/SceneSerializer.cpp
@@ -1,0 +1,215 @@
+#include "Game/SceneSerializer.h"
+
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <stdexcept>
+
+#include "Core/Logger.h"
+#include "Game/Actor.h"
+#include "Game/Object.h"
+#include "Game/Scene.h"
+
+namespace Engine::Game
+{
+    namespace
+    {
+        constexpr std::uint32_t kSceneBinaryVersion = 1;
+
+        void WriteUint32(std::ostream& stream, std::uint32_t value)
+        {
+            stream.write(reinterpret_cast<const char*>(&value), sizeof(value));
+        }
+
+        void ReadUint32(std::istream& stream, std::uint32_t& value)
+        {
+            stream.read(reinterpret_cast<char*>(&value), sizeof(value));
+            if (!stream)
+                throw std::runtime_error("Failed to read uint32_t from stream.");
+        }
+
+        void WriteString(std::ostream& stream, std::string_view value)
+        {
+            const auto length = static_cast<std::uint32_t>(value.size());
+            WriteUint32(stream, length);
+            stream.write(value.data(), static_cast<std::streamsize>(length));
+        }
+
+        std::string ReadString(std::istream& stream)
+        {
+            std::uint32_t length = 0;
+            ReadUint32(stream, length);
+            std::string result(length, '\0');
+            stream.read(result.data(), static_cast<std::streamsize>(length));
+            if (!stream)
+                throw std::runtime_error("Failed to read string from stream.");
+            return result;
+        }
+    }
+
+    bool SceneSerializer::SaveBinary(const Scene& scene, const std::filesystem::path& filePath)
+    {
+        std::ofstream file(filePath, std::ios::binary);
+        if (!file.is_open())
+        {
+            LOG_ERROR("Failed to open binary scene file for writing: " + filePath.string());
+            return false;
+        }
+
+        WriteUint32(file, kSceneBinaryVersion);
+        WriteString(file, std::string(scene.Name()));
+
+        const auto actorCount = static_cast<std::uint32_t>(scene.GetActors().size());
+        WriteUint32(file, actorCount);
+
+        for (const auto& actor : scene.GetActors())
+        {
+            WriteString(file, std::string(actor->GetTypeName()));
+            actor->SerializeBinary(file);
+        }
+
+        return static_cast<bool>(file);
+    }
+
+    bool SceneSerializer::LoadBinary(Scene& scene, const std::filesystem::path& filePath)
+    {
+        std::ifstream file(filePath, std::ios::binary);
+        if (!file.is_open())
+        {
+            LOG_ERROR("Failed to open binary scene file for reading: " + filePath.string());
+            return false;
+        }
+
+        std::uint32_t version = 0;
+        try
+        {
+            ReadUint32(file, version);
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR(std::string("Failed to read scene header: ") + e.what());
+            return false;
+        }
+
+        if (version != kSceneBinaryVersion)
+        {
+            LOG_ERROR("Unsupported scene binary version: " + std::to_string(version));
+            return false;
+        }
+
+        try
+        {
+            scene.Rename(ReadString(file));
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR(std::string("Failed to read scene name: ") + e.what());
+            return false;
+        }
+
+        scene.ClearActors();
+
+        std::uint32_t actorCount = 0;
+        try
+        {
+            ReadUint32(file, actorCount);
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR(std::string("Failed to read actor count: ") + e.what());
+            return false;
+        }
+
+        for (std::uint32_t i = 0; i < actorCount; ++i)
+        {
+            std::string type;
+            try
+            {
+                type = ReadString(file);
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERROR(std::string("Failed to read actor type: ") + e.what());
+                return false;
+            }
+            auto actor = CreateActor(type);
+            if (!actor)
+            {
+                LOG_ERROR("No actor factory registered for type: " + type);
+                return false;
+            }
+
+            try
+            {
+                actor->DeserializeBinary(file);
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERROR(std::string("Failed to deserialize actor ") + type + ": " + e.what());
+                return false;
+            }
+
+            scene.AddActor(std::move(actor));
+        }
+
+        return true;
+    }
+
+    void SceneSerializer::RegisterActorFactory(std::string typeName, ActorFactory factory)
+    {
+        if (typeName.empty() || !factory)
+            return;
+
+        auto& factories = GetFactories();
+        factories[std::move(typeName)] = std::move(factory);
+    }
+
+    void SceneSerializer::UnregisterActorFactory(std::string_view typeName)
+    {
+        auto& factories = GetFactories();
+        factories.erase(std::string(typeName));
+    }
+
+    void SceneSerializer::ClearActorFactories()
+    {
+        auto& factories = GetFactories();
+        factories.clear();
+        EnsureDefaultFactories();
+    }
+
+    std::unique_ptr<Actor> SceneSerializer::CreateActor(std::string_view typeName)
+    {
+        auto& factories = GetFactories();
+        const auto it = factories.find(std::string(typeName));
+        if (it == factories.end())
+            return nullptr;
+
+        return it->second();
+    }
+
+    std::unordered_map<std::string, SceneSerializer::ActorFactory>& SceneSerializer::GetFactories()
+    {
+        static std::unordered_map<std::string, ActorFactory> factories;
+        static bool defaultsRegistered = false;
+
+        if (!defaultsRegistered)
+        {
+            factories["Actor"] = []() { return std::make_unique<Actor>(); };
+            defaultsRegistered = true;
+        }
+
+        return factories;
+    }
+
+    void SceneSerializer::EnsureDefaultFactories()
+    {
+        auto& factories = GetFactories();
+        if (!factories.contains("Actor"))
+        {
+            factories["Actor"] = []() { return std::make_unique<Actor>(); };
+        }
+    }
+}

--- a/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Test/Player.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Game/Private/Game/Test/Player.cpp
@@ -1,15 +1,45 @@
 #include "Game/Test/Player.h"
+
+#include <istream>
 #include <memory>
+#include <ostream>
+#include <stdexcept>
+
 #include "Game/Components/SpriteComponent.h"
+#include "Game/SceneSerializer.h"
 #include "Input/InputManager.h"
 #include "Math/Math.h"
 
 namespace Engine::Game
 {
+    namespace
+    {
+        struct PlayerFactoryRegistration
+        {
+            PlayerFactoryRegistration()
+            {
+                SceneSerializer::RegisterActorFactory("Player", []()
+                {
+                    return std::make_unique<Player>();
+                });
+            }
+        };
+
+        static PlayerFactoryRegistration g_playerFactoryRegistration;
+    }
+
+    Player::Player()
+        : Actor("Player")
+    {
+        InitializeSpriteComponent();
+    }
+
     Player::Player(const Math::Vector3& position, const Math::Vector3& size, SDL_Color color)
         : Actor(Math::Transform(position, Math::Rotator(), size))
     {
-        AddComponent(std::make_unique<SpriteComponent>(this, color, size.x, size.y));
+        size_ = size;
+        color_ = color;
+        InitializeSpriteComponent();
     }
 
     void Player::SetupInput(Input::InputManager& inputManager)
@@ -54,6 +84,49 @@ namespace Engine::Game
         movement = movement * (moveSpeed_ * deltaTime);
 
         SetPosition(GetPosition() + movement);
+    }
+
+    void Player::SerializeBinaryImpl(std::ostream& stream) const
+    {
+        WritePrimitive(stream, moveSpeed_);
+        stream.write(reinterpret_cast<const char*>(&color_), sizeof(color_));
+        WritePrimitive(stream, size_.x);
+        WritePrimitive(stream, size_.y);
+        WritePrimitive(stream, size_.z);
+    }
+
+    void Player::DeserializeBinaryImpl(std::istream& stream)
+    {
+        ReadPrimitive(stream, moveSpeed_);
+        stream.read(reinterpret_cast<char*>(&color_), sizeof(color_));
+        if (!stream)
+            throw std::runtime_error("Failed to read player color from stream.");
+        ReadPrimitive(stream, size_.x);
+        ReadPrimitive(stream, size_.y);
+        ReadPrimitive(stream, size_.z);
+
+        RefreshSpriteComponent();
+        SetScale(size_);
+    }
+
+    void Player::InitializeSpriteComponent()
+    {
+        auto sprite = std::make_unique<SpriteComponent>(this, color_, size_.x, size_.y);
+        spriteComponent_ = sprite.get();
+        AddComponent(std::move(sprite));
+        SetScale(size_);
+    }
+
+    void Player::RefreshSpriteComponent()
+    {
+        if (!spriteComponent_)
+        {
+            InitializeSpriteComponent();
+            return;
+        }
+
+        spriteComponent_->SetColor(color_);
+        spriteComponent_->SetDimensions(size_.x, size_.y);
     }
 }
 

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Actor.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Actor.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <memory>
+#include <string>
 #include <vector>
+#include "Game/Object.h"
 #include "Math/Math.h"
 
 namespace Engine::Graphics { class Renderer; }
@@ -9,10 +11,11 @@ namespace Engine::Game
 {
     class Component;
     
-    class Actor
+    class Actor : public Object
     {
         public:
             explicit Actor(const Math::Transform& transform = Math::Transform());
+            Actor(std::string name, const Math::Transform& transform = Math::Transform());
             virtual ~Actor();
 
             virtual void BeginPlay();
@@ -21,29 +24,9 @@ namespace Engine::Game
 
              void AddComponent(std::unique_ptr<Component> component);
 
-            [[nodiscard]] Math::Vector3 GetPosition() const noexcept { return transform_.position; }
-            [[nodiscard]] Math::Rotator GetRotation() const noexcept { return transform_.rotation; }
-            [[nodiscard]] Math::Vector3 GetScale() const noexcept { return transform_.scale; }
-
-            void SetPosition(const Math::Vector3& position) { transform_.position = position; }
-            void SetRotation(const Math::Rotator& rotation) { transform_.rotation = rotation; }
-            void SetScale(const Math::Vector3& scale)       { transform_.scale = scale; }
-
-            void SetPositionX(float x) { transform_.position.x = x; }
-            void SetPositionY(float y) { transform_.position.y = y; }
-            void SetPositionZ(float z) { transform_.position.z = z; }
-
-            void SetScaleX(float x) { transform_.scale.x = x; }
-            void SetScaleY(float y) { transform_.scale.y = y; }
-            void SetScaleZ(float z) { transform_.scale.z = z; }
-
-            void SetRotationPitch(float pitch) { transform_.rotation.pitch = pitch; }
-            void SetRotationYaw(float yaw)     { transform_.rotation.yaw = yaw; }
-            void SetRotationRoll(float roll)   { transform_.rotation.roll = roll; }
+            [[nodiscard]] std::string_view GetTypeName() const noexcept override { return "Actor"; }
 
         private:
-        Math::Transform transform_;
-        
         std::vector<std::unique_ptr<Component>> components_;
 
         bool hasBegunPlay_{false};

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/SpriteComponent.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/SpriteComponent.h
@@ -12,6 +12,17 @@ namespace Engine::Game
 
             void Render(Graphics::Renderer& renderer) const override;
 
+            void SetColor(SDL_Color color) noexcept { color_ = color; }
+            void SetDimensions(float w, float h) noexcept
+            {
+                width_ = w;
+                height_ = h;
+            }
+
+            [[nodiscard]] SDL_Color GetColor() const noexcept { return color_; }
+            [[nodiscard]] float GetWidth() const noexcept { return width_; }
+            [[nodiscard]] float GetHeight() const noexcept { return height_; }
+
         private:
             SDL_Color color_;
             float width_;

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Object.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Object.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <string_view>
+
+#include "Math/Math.h"
+
+namespace Engine::Game
+{
+    class Object
+    {
+    public:
+        Object();
+        explicit Object(std::string name);
+        Object(std::string name, const Math::Transform& transform);
+        virtual ~Object() = default;
+
+        [[nodiscard]] std::string_view GetUUID() const noexcept { return uuid_; }
+        void SetUUID(std::string uuid);
+
+        [[nodiscard]] std::string_view GetName() const noexcept { return name_; }
+        void SetName(std::string name);
+
+        [[nodiscard]] virtual std::string_view GetTypeName() const noexcept;
+
+        [[nodiscard]] const Math::Transform& GetTransform() const noexcept { return transform_; }
+        void SetTransform(const Math::Transform& transform) noexcept { transform_ = transform; }
+
+        [[nodiscard]] Math::Vector3 GetPosition() const noexcept { return transform_.position; }
+        void SetPosition(const Math::Vector3& position) noexcept { transform_.position = position; }
+        void SetPositionX(float x) noexcept { transform_.position.x = x; }
+        void SetPositionY(float y) noexcept { transform_.position.y = y; }
+        void SetPositionZ(float z) noexcept { transform_.position.z = z; }
+
+        [[nodiscard]] Math::Rotator GetRotation() const noexcept { return transform_.rotation; }
+        void SetRotation(const Math::Rotator& rotation) noexcept { transform_.rotation = rotation; }
+        void SetRotationPitch(float pitch) noexcept { transform_.rotation.pitch = pitch; }
+        void SetRotationYaw(float yaw) noexcept { transform_.rotation.yaw = yaw; }
+        void SetRotationRoll(float roll) noexcept { transform_.rotation.roll = roll; }
+
+        [[nodiscard]] Math::Vector3 GetScale() const noexcept { return transform_.scale; }
+        void SetScale(const Math::Vector3& scale) noexcept { transform_.scale = scale; }
+        void SetScaleX(float x) noexcept { transform_.scale.x = x; }
+        void SetScaleY(float y) noexcept { transform_.scale.y = y; }
+        void SetScaleZ(float z) noexcept { transform_.scale.z = z; }
+
+        virtual void SerializeBinary(std::ostream& stream) const;
+        virtual void DeserializeBinary(std::istream& stream);
+
+    protected:
+        [[nodiscard]] Math::Transform& GetMutableTransform() noexcept { return transform_; }
+
+        virtual void SerializeBinaryImpl(std::ostream& stream) const {}
+        virtual void DeserializeBinaryImpl(std::istream& stream) {}
+
+        template<typename T>
+        static void WritePrimitive(std::ostream& stream, const T& value)
+        {
+            stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
+        }
+
+        template<typename T>
+        static void ReadPrimitive(std::istream& stream, T& value)
+        {
+            stream.read(reinterpret_cast<char*>(&value), sizeof(T));
+        }
+
+        static void WriteString(std::ostream& stream, std::string_view value);
+        static std::string ReadString(std::istream& stream);
+
+    private:
+        static std::string GenerateUUID();
+
+        void SerializeTransform(std::ostream& stream) const;
+        void DeserializeTransform(std::istream& stream);
+
+        std::string uuid_;
+        std::string name_;
+        Math::Transform transform_{};
+    };
+}

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Scene.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Scene.h
@@ -41,6 +41,12 @@ namespace Engine
                 void SetContext(SceneContext context) noexcept;
 
                 void AddActor(std::unique_ptr<Actor> actor);
+                void ClearActors() noexcept;
+
+                [[nodiscard]] const std::vector<std::unique_ptr<Actor>>& GetActors() const noexcept { return actors_; }
+                [[nodiscard]] std::vector<std::unique_ptr<Actor>>& GetActors() noexcept { return actors_; }
+
+                void Rename(std::string name);
 
                 [[nodiscard]] std::string_view Name() const noexcept { return name_; }
 

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/SceneSerializer.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/SceneSerializer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace Engine::Game
+{
+    class Actor;
+    class Scene;
+
+    class SceneSerializer
+    {
+    public:
+        using ActorFactory = std::function<std::unique_ptr<Actor>()>;
+
+        static bool SaveBinary(const Scene& scene, const std::filesystem::path& filePath);
+        static bool LoadBinary(Scene& scene, const std::filesystem::path& filePath);
+
+        static void RegisterActorFactory(std::string typeName, ActorFactory factory);
+        static void UnregisterActorFactory(std::string_view typeName);
+        static void ClearActorFactories();
+
+    private:
+        static std::unique_ptr<Actor> CreateActor(std::string_view typeName);
+        static std::unordered_map<std::string, ActorFactory>& GetFactories();
+        static void EnsureDefaultFactories();
+    };
+}

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Test/Player.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Test/Player.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <SDL3/SDL.h>
+#include <iosfwd>
 #include "Game/Actor.h"
 
 namespace Engine
@@ -14,6 +15,7 @@ namespace Engine
         class Player : public Actor
         {
             public:
+                Player();
                 Player(const Math::Vector3& position, const Math::Vector3& size, SDL_Color color);
 
                 void SetupInput(Input::InputManager& inputManager);
@@ -23,11 +25,21 @@ namespace Engine
                 void MoveForward(float value);
                 void MoveRight(float value);
 
+                [[nodiscard]] std::string_view GetTypeName() const noexcept override { return "Player"; }
+
             private:
+                void SerializeBinaryImpl(std::ostream& stream) const override;
+                void DeserializeBinaryImpl(std::istream& stream) override;
+
                 void ApplyMovement(float deltaTime);
+                void InitializeSpriteComponent();
+                void RefreshSpriteComponent();
 
                 Math::Vector2 pendingInput_{};
                 float moveSpeed_{200.0f};
+                Math::Vector3 size_{Math::Vector3(32.0f, 32.0f, 1.0f)};
+                SDL_Color color_{255, 255, 255, 255};
+                SpriteComponent* spriteComponent_{nullptr};
         };
     }
 }


### PR DESCRIPTION
## Summary
- remove JSON serialization hooks from gameplay objects so they rely solely on binary persistence
- update SceneSerializer to expose only binary save/load and keep the actor factory system intact
- delete the vendored nlohmann::json header now that JSON scene serialization is no longer supported

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7e5f2ab088330a10935fc7916d358