### PR TITLE
Restore object transform accessors

### DIFF
--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Object.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Object.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <istream>
+#include <ostream>
 #include <string>
 #include <string_view>
-#include <istream>   // 👈 nécessaire pour std::istream::read
-#include <ostream>   // 👈 nécessaire pour std::ostream::write
 
 #include "Math/Math.h"
 
@@ -17,7 +17,26 @@ namespace Engine::Game
         Object(std::string name, const Math::Transform& transform);
         virtual ~Object() = default;
 
-        // ... (le reste de ton code identique)
+        [[nodiscard]] virtual std::string_view GetTypeName() const noexcept;
+
+        [[nodiscard]] const std::string& GetUUID() const noexcept { return uuid_; }
+        void SetUUID(std::string uuid);
+
+        [[nodiscard]] const std::string& GetName() const noexcept { return name_; }
+        void SetName(std::string name);
+
+        [[nodiscard]] const Math::Transform& GetTransform() const noexcept { return transform_; }
+        void SetTransform(const Math::Transform& transform) noexcept { transform_ = transform; }
+
+        [[nodiscard]] const Math::Vector3& GetPosition() const noexcept { return transform_.position; }
+        void SetPosition(const Math::Vector3& position) noexcept { transform_.position = position; }
+        void SetPosition(float x, float y, float z = 0.0f) noexcept { transform_.position = { x, y, z }; }
+
+        [[nodiscard]] const Math::Rotator& GetRotation() const noexcept { return transform_.rotation; }
+        void SetRotation(const Math::Rotator& rotation) noexcept { transform_.rotation = rotation; }
+
+        [[nodiscard]] const Math::Vector3& GetScale() const noexcept { return transform_.scale; }
+        void SetScale(const Math::Vector3& scale) noexcept { transform_.scale = scale; }
 
         virtual void SerializeBinary(std::ostream& stream) const;
         virtual void DeserializeBinary(std::istream& stream);


### PR DESCRIPTION
## Summary
- expose Object type-name accessor so derived classes can override it
- provide transform getters and setters used by actors and components

## Testing
- not run (msbuild GameEngine.sln)

------
https://chatgpt.com/codex/tasks/task_e_68d7f24f74e883308b991f56d6d7b6ef