### PR TITLE
Add configurable ImGui layout system

### DIFF
--- a/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
@@ -18,7 +18,9 @@
 #include "Gui/GuiManager.h"
 #include "Gui/GuiPanel.h"
 #include "Gui/GuiSystem.h"
+#include "Gui/LayoutSystem.h"
 #include "Gui/DefaultEngineGui.h"
+#include "imgui.h"
 
 namespace Engine::Core
 {
@@ -167,7 +169,12 @@ namespace Engine::Core
             return;
 
         if (guiManager_)
+        {
+            ImGuiIO& io = ImGui::GetIO();
+            if (io.ConfigFlags & ImGuiConfigFlags_DockingEnable)
+                ImGui::DockSpaceOverViewport(ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
             guiManager_->DrawAll();
+        }
 
         guiSystem_->EndFrame();
         guiSystem_->Render();
@@ -303,6 +310,9 @@ namespace Engine::Core
         statsPanel_ = panels.statsPanel;
         outlinerPanel_ = panels.sceneOutlinerPanel;
         contentBrowserPanel_ = panels.contentBrowserPanel;
+
+        if (guiSystem_)
+            guiSystem_->GetLayoutSystem().CaptureDefaultLayout();
     }
 
 // === Shutdown ===

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/GuiPanel.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/GuiPanel.cpp
@@ -7,11 +7,13 @@ namespace Engine::Gui
     GuiPanel::GuiPanel(String name, String title)
         : name_(std::move(name)), title_(std::move(title))
     {
+        UpdateWindowLabel();
     }
 
     void GuiPanel::SetTitle(String title)
     {
         title_ = std::move(title);
+        UpdateWindowLabel();
     }
 
     void GuiPanel::SetPosition(float x, float y, ImGuiCond condition) noexcept
@@ -68,8 +70,8 @@ namespace Engine::Gui
 
         bool open = visible_;
         const bool shouldShow = closable_
-            ? ImGui::Begin(title_.c_str(), &open, finalFlags)
-            : ImGui::Begin(title_.c_str(), nullptr, finalFlags);
+            ? ImGui::Begin(windowLabel_.c_str(), &open, finalFlags)
+            : ImGui::Begin(windowLabel_.c_str(), nullptr, finalFlags);
 
         if (closable_)
             visible_ = open;
@@ -81,5 +83,12 @@ namespace Engine::Gui
 
         if (useBackgroundColor_)
             ImGui::PopStyleColor();
+    }
+
+    void GuiPanel::UpdateWindowLabel()
+    {
+        windowLabel_ = title_;
+        windowLabel_ += "###";
+        windowLabel_ += name_;
     }
 }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/GuiSystem.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/GuiSystem.cpp
@@ -8,6 +8,7 @@
 
 #include "Core/Logger.h"
 #include "Gui/GuiPanel.h"
+#include "Gui/LayoutSystem.h"
 
 #include "imgui.h"
 #include "imgui_impl_sdl3.h"
@@ -15,6 +16,11 @@
 
 namespace Engine::Gui
 {
+    GuiSystem::GuiSystem()
+        : layoutSystem_(std::make_unique<LayoutSystem>())
+    {
+    }
+
     GuiSystem::~GuiSystem()
     {
         Shutdown();
@@ -39,6 +45,7 @@ namespace Engine::Gui
 
         ImGuiIO& io = ImGui::GetIO();
         io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
         ImGui::StyleColorsDark();
 
@@ -81,6 +88,9 @@ namespace Engine::Gui
             return;
 
         panels_.clear();
+
+        if (layoutSystem_)
+            layoutSystem_->Clear();
 
         ImGui_ImplSDLRenderer3_Shutdown();
         ImGui_ImplSDL3_Shutdown();
@@ -148,6 +158,9 @@ namespace Engine::Gui
     {
         if (std::find(panels_.begin(), panels_.end(), &panel) == panels_.end())
             panels_.push_back(&panel);
+
+        if (layoutSystem_)
+            layoutSystem_->RegisterPanel(&panel);
     }
 
     void GuiSystem::UnregisterPanel(GuiPanel& panel)
@@ -155,5 +168,8 @@ namespace Engine::Gui
         auto it = std::find(panels_.begin(), panels_.end(), &panel);
         if (it != panels_.end())
             panels_.erase(it);
+
+        if (layoutSystem_)
+            layoutSystem_->UnregisterPanel(&panel);
     }
 }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/LayoutSystem.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/LayoutSystem.cpp
@@ -1,0 +1,358 @@
+#include "Gui/LayoutSystem.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+
+#include "Gui/GuiPanel.h"
+
+#include "imgui.h"
+
+namespace Engine::Gui
+{
+    namespace
+    {
+        constexpr float kScaleEpsilon = 0.001f;
+
+        [[nodiscard]] bool IsFloatChar(char c) noexcept
+        {
+            return (c >= '0' && c <= '9') || c == '-' || c == '+' || c == '.' || c == ',';
+        }
+    }
+
+    void LayoutSystem::RegisterPanel(GuiPanel* panel)
+    {
+        if (!panel)
+            return;
+
+        panels_[panel->GetName()] = panel;
+    }
+
+    void LayoutSystem::UnregisterPanel(GuiPanel* panel)
+    {
+        if (!panel)
+            return;
+
+        const String& name = panel->GetName();
+        if (auto it = panels_.find(name); it != panels_.end() && it->second == panel)
+        {
+            panels_.erase(it);
+            return;
+        }
+
+        for (auto it = panels_.begin(); it != panels_.end(); ++it)
+        {
+            if (it->second == panel)
+            {
+                panels_.erase(it);
+                break;
+            }
+        }
+    }
+
+    void LayoutSystem::Clear() noexcept
+    {
+        panels_.clear();
+        defaultVisibility_.clear();
+        defaultLayout_.clear();
+        defaultReferenceWidth_ = 0.0f;
+        defaultReferenceHeight_ = 0.0f;
+    }
+
+    bool LayoutSystem::SaveLayout(const std::filesystem::path& filePath) const
+    {
+        if (!ImGui::GetCurrentContext())
+            return false;
+
+        size_t iniSize = 0;
+        const char* iniData = ImGui::SaveIniSettingsToMemory(&iniSize);
+        if (!iniData || iniSize == 0)
+            return false;
+
+        const ImGuiIO& io = ImGui::GetIO();
+        const float referenceWidth = io.DisplaySize.x;
+        const float referenceHeight = io.DisplaySize.y;
+
+        if (!filePath.parent_path().empty())
+        {
+            std::error_code ec;
+            std::filesystem::create_directories(filePath.parent_path(), ec);
+        }
+
+        std::ofstream file(filePath);
+        if (!file.is_open())
+            return false;
+
+        file << "# LayoutVersion 1\n";
+        file << "ReferenceSize " << referenceWidth << ' ' << referenceHeight << "\n";
+        size_t panelCount = 0;
+        for (const auto& entry : panels_)
+        {
+            if (entry.second)
+                ++panelCount;
+        }
+
+        file << "Panels " << panelCount << "\n";
+
+        for (const auto& [name, panel] : panels_)
+        {
+            if (!panel)
+                continue;
+
+            file << "Panel " << std::quoted(name.Std()) << ' ' << (panel->IsVisible() ? 1 : 0) << "\n";
+        }
+
+        file << "[ImGui]\n";
+        file.write(iniData, static_cast<std::streamsize>(iniSize));
+        if (iniSize == 0 || iniData[iniSize - 1] != '\n')
+            file << '\n';
+
+        return file.good();
+    }
+
+    bool LayoutSystem::LoadLayout(const std::filesystem::path& filePath)
+    {
+        if (!ImGui::GetCurrentContext())
+            return false;
+
+        std::ifstream file(filePath);
+        if (!file.is_open())
+            return false;
+
+        float referenceWidth = 0.0f;
+        float referenceHeight = 0.0f;
+        std::unordered_map<String, bool> visibility;
+        std::string iniData;
+        bool inIniSection = false;
+
+        std::string line;
+        while (std::getline(file, line))
+        {
+            if (!inIniSection)
+            {
+                if (line.empty())
+                    continue;
+
+                if (line[0] == '#')
+                    continue;
+
+                if (line == "[ImGui]")
+                {
+                    inIniSection = true;
+                    continue;
+                }
+
+                std::istringstream iss(line);
+                std::string token;
+                iss >> token;
+
+                if (token == "ReferenceSize")
+                {
+                    iss >> referenceWidth >> referenceHeight;
+                }
+                else if (token == "Panel")
+                {
+                    std::string name;
+                    iss >> std::quoted(name);
+                    int visible = 1;
+                    iss >> visible;
+                    visibility[String{name}] = visible != 0;
+                }
+
+                continue;
+            }
+
+            iniData.append(line);
+            iniData.push_back('\n');
+        }
+
+        if (iniData.empty())
+            return false;
+
+        ApplyLayout(iniData, referenceWidth, referenceHeight);
+        ApplyPanelVisibility(visibility);
+        return true;
+    }
+
+    void LayoutSystem::ResetToDefault()
+    {
+        if (defaultLayout_.empty())
+            return;
+
+        ApplyLayout(defaultLayout_, defaultReferenceWidth_, defaultReferenceHeight_);
+        ApplyPanelVisibility(defaultVisibility_);
+    }
+
+    void LayoutSystem::CaptureDefaultLayout()
+    {
+        if (!ImGui::GetCurrentContext())
+            return;
+
+        size_t iniSize = 0;
+        const char* iniData = ImGui::SaveIniSettingsToMemory(&iniSize);
+        if (!iniData || iniSize == 0)
+            return;
+
+        const ImGuiIO& io = ImGui::GetIO();
+        defaultReferenceWidth_ = io.DisplaySize.x;
+        defaultReferenceHeight_ = io.DisplaySize.y;
+        defaultLayout_.assign(iniData, iniSize);
+
+        defaultVisibility_.clear();
+        for (const auto& [name, panel] : panels_)
+        {
+            if (panel)
+                defaultVisibility_[name] = panel->IsVisible();
+        }
+    }
+
+    GuiPanel* LayoutSystem::FindPanel(const String& name) const
+    {
+        if (auto it = panels_.find(name); it != panels_.end())
+            return it->second;
+
+        return nullptr;
+    }
+
+    void LayoutSystem::ApplyLayout(const std::string& iniData, float referenceWidth, float referenceHeight)
+    {
+        if (!ImGui::GetCurrentContext() || iniData.empty())
+            return;
+
+        const ImGuiIO& io = ImGui::GetIO();
+        const float width = io.DisplaySize.x;
+        const float height = io.DisplaySize.y;
+
+        const float scaleX = (referenceWidth > 0.0f) ? width / referenceWidth : 1.0f;
+        const float scaleY = (referenceHeight > 0.0f) ? height / referenceHeight : 1.0f;
+
+        const std::string scaledIni = ScaleIniData(iniData, scaleX, scaleY);
+        ImGui::LoadIniSettingsFromMemory(scaledIni.c_str(), scaledIni.size());
+    }
+
+    void LayoutSystem::ApplyPanelVisibility(const std::unordered_map<String, bool>& visibility)
+    {
+        for (const auto& [name, visible] : visibility)
+        {
+            if (GuiPanel* panel = FindPanel(name))
+                panel->SetVisible(visible);
+        }
+    }
+
+    std::string LayoutSystem::ScaleIniData(const std::string& iniData, float scaleX, float scaleY)
+    {
+        if (iniData.empty())
+            return {};
+
+        if (std::abs(scaleX - 1.0f) < kScaleEpsilon && std::abs(scaleY - 1.0f) < kScaleEpsilon)
+            return iniData;
+
+        std::string result = iniData;
+        const std::array<std::string_view, 8> tokens{
+            "Pos=",
+            "Size=",
+            "SizeRef=",
+            "CentralNodeSize=",
+            "ViewportPos=",
+            "ViewportSize=",
+            "WorkSize=",
+            "WorkPos="
+        };
+
+        for (std::string_view token : tokens)
+        {
+            size_t searchPos = 0;
+            while (searchPos < result.size())
+            {
+                const size_t pos = result.find(token, searchPos);
+                if (pos == std::string::npos)
+                    break;
+
+                const size_t valuePos = pos + token.size();
+                size_t endPos = valuePos;
+                while (endPos < result.size() && IsFloatChar(result[endPos]))
+                    ++endPos;
+
+                if (endPos <= valuePos)
+                {
+                    searchPos = pos + token.size();
+                    continue;
+                }
+
+                std::string value = result.substr(valuePos, endPos - valuePos);
+                float x = 0.0f;
+                float y = 0.0f;
+
+                if (ParseFloatPair(value, x, y))
+                {
+                    x *= scaleX;
+                    y *= scaleY;
+
+                    const std::string replacement = FormatFloat(x) + ',' + FormatFloat(y);
+                    result.replace(valuePos, value.size(), replacement);
+                    searchPos = valuePos + replacement.size();
+                }
+                else
+                {
+                    searchPos = pos + token.size();
+                }
+            }
+        }
+
+        return result;
+    }
+
+    bool LayoutSystem::ParseFloatPair(const std::string& value, float& outX, float& outY)
+    {
+        const char* data = value.c_str();
+        while (*data && std::isspace(static_cast<unsigned char>(*data)))
+            ++data;
+
+        char* endPtr = nullptr;
+        outX = std::strtof(data, &endPtr);
+        if (endPtr == data)
+            return false;
+
+        while (*endPtr && std::isspace(static_cast<unsigned char>(*endPtr)))
+            ++endPtr;
+
+        if (*endPtr != ',')
+            return false;
+
+        ++endPtr;
+        while (*endPtr && std::isspace(static_cast<unsigned char>(*endPtr)))
+            ++endPtr;
+
+        char* finalPtr = nullptr;
+        outY = std::strtof(endPtr, &finalPtr);
+        if (finalPtr == endPtr)
+            return false;
+
+        return true;
+    }
+
+    std::string LayoutSystem::FormatFloat(float value)
+    {
+        std::ostringstream oss;
+        oss << std::fixed << std::setprecision(3) << value;
+        std::string result = oss.str();
+
+        while (!result.empty() && result.back() == '0')
+            result.pop_back();
+
+        if (!result.empty() && result.back() == '.')
+            result.pop_back();
+
+        if (result.empty())
+            result = "0";
+
+        return result;
+    }
+}

--- a/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/GuiPanel.h
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/GuiPanel.h
@@ -48,6 +48,7 @@ namespace Engine::Gui
         private:
             String name_;
             String title_;
+            String windowLabel_;
             bool visible_{true};
 
             bool usePosition_{false};
@@ -69,5 +70,7 @@ namespace Engine::Gui
             ImVec4 backgroundColor_{1.0f, 1.0f, 1.0f, 1.0f};
 
             DrawFunction drawFunction_{};
+
+            void UpdateWindowLabel();
     };
 }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/GuiSystem.h
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/GuiSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include <SDL3/SDL_events.h>
@@ -10,11 +11,12 @@ struct SDL_Renderer;
 namespace Engine::Gui
 {
     class GuiPanel;
+    class LayoutSystem;
 
     class GuiSystem
     {
         public:
-            GuiSystem() = default;
+            GuiSystem();
             ~GuiSystem();
 
             GuiSystem(const GuiSystem&) = delete;
@@ -36,6 +38,9 @@ namespace Engine::Gui
 
             [[nodiscard]] bool IsInitialized() const noexcept { return initialized_; }
 
+            [[nodiscard]] LayoutSystem& GetLayoutSystem() noexcept { return *layoutSystem_; }
+            [[nodiscard]] const LayoutSystem& GetLayoutSystem() const noexcept { return *layoutSystem_; }
+
         private:
             SDL_Window* window_{nullptr};
             SDL_Renderer* renderer_{nullptr};
@@ -43,5 +48,6 @@ namespace Engine::Gui
             bool frameBegun_{false};
 
             std::vector<GuiPanel*> panels_{};
+            std::unique_ptr<LayoutSystem> layoutSystem_{};
     };
 }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/LayoutSystem.h
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/LayoutSystem.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+#include "Core/String.h"
+
+namespace Engine::Gui
+{
+    class GuiPanel;
+
+    class LayoutSystem
+    {
+        public:
+            LayoutSystem() = default;
+
+            void RegisterPanel(GuiPanel* panel);
+            void UnregisterPanel(GuiPanel* panel);
+            void Clear() noexcept;
+
+            bool SaveLayout(const std::filesystem::path& filePath) const;
+            bool LoadLayout(const std::filesystem::path& filePath);
+
+            void ResetToDefault();
+            void CaptureDefaultLayout();
+
+            [[nodiscard]] bool HasDefaultLayout() const noexcept { return !defaultLayout_.empty(); }
+
+        private:
+            using PanelMap = std::unordered_map<String, GuiPanel*>;
+
+            [[nodiscard]] GuiPanel* FindPanel(const String& name) const;
+            void ApplyLayout(const std::string& iniData, float referenceWidth, float referenceHeight);
+            void ApplyPanelVisibility(const std::unordered_map<String, bool>& visibility);
+
+            [[nodiscard]] static std::string ScaleIniData(const std::string& iniData, float scaleX, float scaleY);
+            [[nodiscard]] static bool ParseFloatPair(const std::string& value, float& outX, float& outY);
+            [[nodiscard]] static std::string FormatFloat(float value);
+
+            PanelMap panels_{};
+            std::unordered_map<String, bool> defaultVisibility_{};
+            std::string defaultLayout_{};
+            float defaultReferenceWidth_{0.0f};
+            float defaultReferenceHeight_{0.0f};
+    };
+}

--- a/GameEngine/GameEngine/GameEngine.vcxproj
+++ b/GameEngine/GameEngine/GameEngine.vcxproj
@@ -254,6 +254,7 @@
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiManager.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiPanel.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiSystem.cpp" />
+    <ClCompile Include="Engine\Source\Engine\Private\Gui\LayoutSystem.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Widgets\ActionTooltip.cpp" />
     <ClCompile Include="Engine\Source\Game\Private\Game\ActorSpawner.cpp">
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
@@ -1807,6 +1808,7 @@
     <ClInclude Include="Engine\Source\Engine\Public\Gui\GuiManager.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\GuiPanel.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\GuiSystem.h" />
+    <ClInclude Include="Engine\Source\Engine\Public\Gui\LayoutSystem.h" />
     <ClInclude Include="Engine\Source\Core\Public\Core\Logger.h" />
     <ClInclude Include="Engine\Source\Game\Public\Game\ActorSpawner.h" />
     <ClInclude Include="Engine\Source\Game\Public\Game\Object.h" />

--- a/GameEngine/GameEngine/GameEngine.vcxproj.filters
+++ b/GameEngine/GameEngine/GameEngine.vcxproj.filters
@@ -148,6 +148,9 @@
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiSystem.cpp">
       <Filter>Source\Engine\Private\Gui</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Source\Engine\Private\Gui\LayoutSystem.cpp">
+      <Filter>Source\Engine\Private\Gui</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Widgets\ActionTooltip.cpp">
       <Filter>Source\Engine\Private\Gui</Filter>
     </ClCompile>
@@ -271,6 +274,9 @@
       <Filter>Source\Engine\Public\Gui</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Source\Engine\Public\Gui\GuiSystem.h">
+      <Filter>Source\Engine\Public\Gui</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Source\Engine\Public\Gui\LayoutSystem.h">
       <Filter>Source\Engine\Public\Gui</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Source\Core\Public\Core\Logger.h">


### PR DESCRIPTION
## Summary
- add a dedicated `LayoutSystem` for registering panels and saving, loading, or resetting ImGui layouts with resolution scaling
- enable docking support, central dockspace creation, and default layout capture within the GUI flow
- keep panel window IDs stable and update project files to build the new layout system

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0232de754833098f348f9a01eea97