### PR TITLE
Add actor inspector panel with selection support

### DIFF
--- a/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Core/Private/Core/Application.cpp
@@ -9,6 +9,7 @@
 #include "Core/Logger.h"
 #include "Core/Timer.h"
 #include "Core/Window.h"
+#include "Game/Actor.h"
 #include "Game/Scene.h"
 #include "Game/SceneManager.h"
 #include "Graphics/Renderer.h"
@@ -287,8 +288,12 @@ namespace Engine::Core
             statsPanel_ = nullptr;
             outlinerPanel_ = nullptr;
             contentBrowserPanel_ = nullptr;
+            inspectorPanel_ = nullptr;
+            selectedActor_ = nullptr;
             return;
         }
+
+        selectedActor_ = nullptr;
 
         const Gui::DefaultEngineGuiContext context{
             timer_.get(),
@@ -296,13 +301,22 @@ namespace Engine::Core
             {
                 return sceneManager_.get();
             },
-            &lastDeltaTime_
+            &lastDeltaTime_,
+            [this]() -> Game::Actor*
+            {
+                return selectedActor_;
+            },
+            [this](Game::Actor* actor)
+            {
+                selectedActor_ = actor;
+            }
         };
 
         const Gui::DefaultEngineGuiPanels panels = Gui::CreateDefaultEngineGui(*guiManager_, context);
         statsPanel_ = panels.statsPanel;
         outlinerPanel_ = panels.sceneOutlinerPanel;
         contentBrowserPanel_ = panels.contentBrowserPanel;
+        inspectorPanel_ = panels.actorInspectorPanel;
     }
 
 // === Shutdown ===
@@ -344,6 +358,8 @@ namespace Engine::Core
         statsPanel_ = nullptr;
         outlinerPanel_ = nullptr;
         contentBrowserPanel_ = nullptr;
+        inspectorPanel_ = nullptr;
+        selectedActor_ = nullptr;
 
         if (guiManager_)
             guiManager_.reset();

--- a/GameEngine/GameEngine/Engine/Source/Core/Public/Core/Application.h
+++ b/GameEngine/GameEngine/Engine/Source/Core/Public/Core/Application.h
@@ -11,7 +11,7 @@ namespace Engine
 
     namespace Graphics { class Renderer; }
     namespace Gui      { class GuiSystem; class GuiManager; class GuiPanel; }
-    namespace Game     { class Scene; class SceneManager; }
+    namespace Game     { class Scene; class SceneManager; class Actor; }
     namespace Input    { class InputManager; class Input; }
     namespace Core     { class Window; class Timer; }
 
@@ -77,6 +77,8 @@ namespace Engine
                 Gui::GuiPanel* statsPanel_{nullptr};
                 Gui::GuiPanel* outlinerPanel_{nullptr};
                 Gui::GuiPanel* contentBrowserPanel_{nullptr};
+                Gui::GuiPanel* inspectorPanel_{nullptr};
+                Game::Actor* selectedActor_{nullptr};
                 std::unique_ptr<Timer> timer_;
         };
     }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/DefaultEngineGui.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/DefaultEngineGui.cpp
@@ -1,5 +1,6 @@
 #include "Gui/DefaultEngineGui.h"
 
+#include "Gui/Panels/ActorInspectorPanel.h"
 #include "Gui/Panels/ContentBrowserPanel.h"
 #include "Gui/Panels/SceneOutlinerPanel.h"
 #include "Gui/Panels/StatsPanel.h"
@@ -19,6 +20,7 @@ namespace Engine::Gui
                 DefaultEngineGuiPanels panels{};
                 panels.statsPanel = &CreateStatsPanel(guiManager_, context_);
                 panels.sceneOutlinerPanel = &CreateSceneOutlinerPanel(guiManager_, context_);
+                panels.actorInspectorPanel = &CreateActorInspectorPanel(guiManager_, context_);
                 panels.contentBrowserPanel = &CreateContentBrowserPanel(guiManager_, context_);
                 return panels;
             }

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/Panels/ActorInspectorPanel.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/Panels/ActorInspectorPanel.cpp
@@ -1,0 +1,177 @@
+#include "Gui/Panels/ActorInspectorPanel.h"
+
+#include "Game/Actor.h"
+#include "Game/Components/Component.h"
+#include "Game/Scene.h"
+#include "Game/SceneManager.h"
+#include "Gui/GuiManager.h"
+#include "Gui/GuiPanel.h"
+
+#include "imgui.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
+namespace Engine::Gui
+{
+    namespace
+    {
+        constexpr ImVec4 kInspectorBackground{0.12f, 0.12f, 0.12f, 0.95f};
+
+        bool ActorBelongsToScene(const Game::Scene& scene, const Game::Actor* actor)
+        {
+            if (!actor)
+                return false;
+
+            const auto& actors = scene.GetActors();
+            return std::any_of(actors.begin(), actors.end(), [actor](const auto& candidate)
+            {
+                return candidate.get() == actor;
+            });
+        }
+
+        void DrawTransformSection(Game::Actor& actor)
+        {
+            if (!ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen))
+                return;
+
+            Math::Vector3 position = actor.GetPosition();
+            if (ImGui::DragFloat3("Location", &position.x, 0.1f, 0.0f, 0.0f, "%.3f"))
+                actor.SetPosition(position);
+
+            Math::Rotator rotation = actor.GetRotation();
+            float rotationValues[3] = { rotation.pitch, rotation.yaw, rotation.roll };
+            if (ImGui::DragFloat3("Rotation", rotationValues, 0.1f, 0.0f, 0.0f, "%.2f"))
+                actor.SetRotation(Math::Rotator(rotationValues[0], rotationValues[1], rotationValues[2]));
+
+            Math::Vector3 scale = actor.GetScale();
+            if (ImGui::DragFloat3("Scale", &scale.x, 0.05f, 0.0f, 0.0f, "%.3f"))
+                actor.SetScale(scale);
+        }
+
+        void DrawComponentSection(const Game::Actor& actor)
+        {
+            if (!ImGui::CollapsingHeader("Components", ImGuiTreeNodeFlags_DefaultOpen))
+                return;
+
+            const auto& components = actor.GetComponents();
+            if (components.empty())
+            {
+                ImGui::TextDisabled("Actor has no components.");
+                return;
+            }
+
+            ImGui::PushID("ActorComponents");
+            for (const auto& component : components)
+            {
+                if (!component)
+                    continue;
+
+                const Engine::String typeName = component->GetTypeName();
+                const auto typeNameView = typeName.View();
+
+                const bool open = ImGui::TreeNodeEx(
+                    component.get(),
+                    ImGuiTreeNodeFlags_DefaultOpen |
+                    ImGuiTreeNodeFlags_SpanFullWidth |
+                    ImGuiTreeNodeFlags_FramePadding,
+                    "%.*s",
+                    static_cast<int>(typeNameView.size()),
+                    typeNameView.data());
+
+                if (open)
+                {
+                    ImGui::TextDisabled("No editable properties available.");
+                    ImGui::TreePop();
+                }
+            }
+            ImGui::PopID();
+        }
+    }
+
+    GuiPanel& CreateActorInspectorPanel(GuiManager& guiManager, const DefaultEngineGuiContext& context)
+    {
+        GuiPanel& inspectorPanel = guiManager.CreatePanel("actor_inspector", "Details");
+        guiManager.SetPanelDockingArea(inspectorPanel, DockSpaceRegion::Right);
+        inspectorPanel.SetResizable(true);
+        inspectorPanel.SetMovable(true);
+        inspectorPanel.SetCollapsable(true);
+        inspectorPanel.SetClosable(true);
+        inspectorPanel.SetBackgroundColor(kInspectorBackground);
+        inspectorPanel.AddWindowFlags(ImGuiWindowFlags_NoCollapse);
+        inspectorPanel.SetDrawFunction([provider = context.sceneManagerProvider,
+                                        getSelectedActor = context.selectedActorGetter,
+                                        setSelectedActor = context.selectedActorSetter]()
+        {
+            ImGui::PushID("ActorInspectorPanel");
+
+            static Game::Actor* lastActorForName = nullptr;
+            static char nameBuffer[256] = "";
+
+            Game::SceneManager* sceneManager = provider ? provider() : nullptr;
+            Game::Scene* activeScene = sceneManager ? sceneManager->GetScene() : nullptr;
+
+            if (!activeScene)
+            {
+                lastActorForName = nullptr;
+                nameBuffer[0] = '\0';
+                ImGui::TextDisabled("No active scene.");
+                ImGui::PopID();
+                return;
+            }
+
+            Game::Actor* selectedActor = getSelectedActor ? getSelectedActor() : nullptr;
+            if (!selectedActor)
+            {
+                lastActorForName = nullptr;
+                nameBuffer[0] = '\0';
+                ImGui::TextDisabled("No actor selected.");
+                ImGui::PopID();
+                return;
+            }
+
+            if (!ActorBelongsToScene(*activeScene, selectedActor))
+            {
+                lastActorForName = nullptr;
+                nameBuffer[0] = '\0';
+
+                if (setSelectedActor)
+                    setSelectedActor(nullptr);
+
+                ImGui::TextDisabled("The selected actor is no longer available.");
+                ImGui::PopID();
+                return;
+            }
+
+            if (selectedActor != lastActorForName)
+            {
+                const Engine::String& actorName = selectedActor->GetName();
+                const auto actorNameView = actorName.View();
+                const std::size_t copyLength = std::min(actorNameView.size(), sizeof(nameBuffer) - 1);
+                std::memcpy(nameBuffer, actorNameView.data(), copyLength);
+                nameBuffer[copyLength] = '\0';
+                lastActorForName = selectedActor;
+            }
+
+            if (ImGui::InputText("Name", nameBuffer, IM_ARRAYSIZE(nameBuffer)))
+                selectedActor->SetName(nameBuffer);
+
+            const Engine::String typeName = selectedActor->GetTypeName();
+            const auto typeNameView = typeName.View();
+            ImGui::TextDisabled("Type: %.*s",
+                static_cast<int>(typeNameView.size()),
+                typeNameView.data());
+
+            ImGui::Separator();
+            DrawTransformSection(*selectedActor);
+
+            ImGui::Separator();
+            DrawComponentSection(*selectedActor);
+
+            ImGui::PopID();
+        });
+
+        return inspectorPanel;
+    }
+}

--- a/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/Panels/SceneOutlinerPanel.cpp
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Private/Gui/Panels/SceneOutlinerPanel.cpp
@@ -27,7 +27,9 @@ namespace Engine::Gui
         outlinerPanel.SetClosable(true);
         outlinerPanel.SetBackgroundColor(kOutlinerBackground);
         outlinerPanel.AddWindowFlags(ImGuiWindowFlags_NoCollapse);
-        outlinerPanel.SetDrawFunction([provider = context.sceneManagerProvider]()
+        outlinerPanel.SetDrawFunction([provider = context.sceneManagerProvider,
+                                       getSelectedActor = context.selectedActorGetter,
+                                       setSelectedActor = context.selectedActorSetter]()
         {
             ImGui::PushID("SceneOutlinerPanel");
 
@@ -46,6 +48,7 @@ namespace Engine::Gui
             const bool hasSearch = !searchQuery.IsEmpty();
 
             const auto& actors = activeScene->GetActors();
+            Game::Actor* selectedActor = getSelectedActor ? getSelectedActor() : nullptr;
 
             const auto matchesFilter = [&searchQuery, hasSearch](const Game::Actor& actor)
             {
@@ -86,6 +89,9 @@ namespace Engine::Gui
             if (ImGui::TreeNodeEx(static_cast<const void*>(activeScene), sceneFlags, "%.*s",
                 static_cast<int>(sceneNameView.size()), sceneNameView.data()))
             {
+                if (ImGui::IsItemClicked() && setSelectedActor)
+                    setSelectedActor(nullptr);
+
                 if (totalActors == 0)
                 {
                     ImGui::TextDisabled("No actors in this scene.");
@@ -103,10 +109,13 @@ namespace Engine::Gui
                         const auto actorTypeView = actorType.View();
 
                         const bool hasName = !actorNameView.empty();
-                        const ImGuiTreeNodeFlags actorFlags =
+                        ImGuiTreeNodeFlags actorFlags =
                             ImGuiTreeNodeFlags_Leaf |
                             ImGuiTreeNodeFlags_NoTreePushOnOpen |
                             ImGuiTreeNodeFlags_SpanFullWidth;
+
+                        if (selectedActor == actor.get())
+                            actorFlags |= ImGuiTreeNodeFlags_Selected;
 
                         if (hasName)
                         {
@@ -119,6 +128,9 @@ namespace Engine::Gui
                             ImGui::TreeNodeEx(actor.get(), actorFlags, "<Unnamed> (%.*s)",
                                 static_cast<int>(actorTypeView.size()), actorTypeView.data());
                         }
+
+                        if (ImGui::IsItemClicked() && setSelectedActor)
+                            setSelectedActor(actor.get());
                     }
 
                     if (hasSearch && filteredActors == 0)

--- a/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/DefaultEngineGui.h
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/DefaultEngineGui.h
@@ -5,7 +5,7 @@
 namespace Engine
 {
     namespace Core { class Timer; }
-    namespace Game { class SceneManager; }
+    namespace Game { class SceneManager; class Actor; }
 }
 
 namespace Engine::Gui
@@ -18,6 +18,8 @@ namespace Engine::Gui
         Core::Timer* timer{nullptr};
         std::function<Game::SceneManager*()> sceneManagerProvider{};
         const float* lastDeltaTime{nullptr};
+        std::function<Game::Actor*()> selectedActorGetter{};
+        std::function<void(Game::Actor*)> selectedActorSetter{};
     };
 
     struct DefaultEngineGuiPanels
@@ -25,6 +27,7 @@ namespace Engine::Gui
         GuiPanel* statsPanel{nullptr};
         GuiPanel* sceneOutlinerPanel{nullptr};
         GuiPanel* contentBrowserPanel{nullptr};
+        GuiPanel* actorInspectorPanel{nullptr};
     };
 
     DefaultEngineGuiPanels CreateDefaultEngineGui(GuiManager& guiManager, const DefaultEngineGuiContext& context);

--- a/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/Panels/ActorInspectorPanel.h
+++ b/GameEngine/GameEngine/Engine/Source/Engine/Public/Gui/Panels/ActorInspectorPanel.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Gui/DefaultEngineGui.h"
+
+namespace Engine::Gui
+{
+    GuiPanel& CreateActorInspectorPanel(GuiManager& guiManager, const DefaultEngineGuiContext& context);
+}

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Actor.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Actor.h
@@ -27,6 +27,9 @@ namespace Engine::Game
 
             [[nodiscard]] virtual std::unique_ptr<Actor> ClonePrototype() const;
 
+        public:
+            [[nodiscard]] const std::vector<std::unique_ptr<Component>>& GetComponents() const noexcept { return components_; }
+
         private:
         std::vector<std::unique_ptr<Component>> components_;
 

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/Component.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/Component.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+#pragma once
+
+#include "Core/String.h"
 
 namespace Engine::Graphics { class Renderer; }
 
@@ -8,15 +10,17 @@ namespace Engine::Game
 
     class Component
     {
-        public:
-            explicit Component(Actor* owner) : owner_(owner) {}
-            virtual ~Component() = default;
+    public:
+        explicit Component(Actor* owner) : owner_(owner) {}
+        virtual ~Component() = default;
 
-            virtual void BeginPlay() {}
-            virtual void Update(float deltaTime) {}
-            virtual void Render(Graphics::Renderer& renderer) const {}
+        virtual void BeginPlay() {}
+        virtual void Update(float deltaTime) {}
+        virtual void Render(Graphics::Renderer& renderer) const {}
 
-        protected:
-            Actor* owner_{nullptr};
+        [[nodiscard]] virtual Engine::String GetTypeName() const { return "Component"; }
+
+    protected:
+        Actor* owner_{nullptr};
     };
 }

--- a/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/SpriteComponent.h
+++ b/GameEngine/GameEngine/Engine/Source/Game/Public/Game/Components/SpriteComponent.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+#pragma once
+
 #include "Game/Components/Component.h"
 #include "SDL3/SDL.h"
 
@@ -6,26 +7,28 @@ namespace Engine::Game
 {
     class SpriteComponent : public Component
     {
-        public:
-            SpriteComponent(Actor* owner, SDL_Color color, float w, float h)
-                : Component(owner), color_(color), width_(w), height_(h) {}
+    public:
+        SpriteComponent(Actor* owner, SDL_Color color, float w, float h)
+            : Component(owner), color_(color), width_(w), height_(h) {}
 
-            void Render(Graphics::Renderer& renderer) const override;
+        void Render(Graphics::Renderer& renderer) const override;
 
-            void SetColor(SDL_Color color) noexcept { color_ = color; }
-            void SetDimensions(float w, float h) noexcept
-            {
-                width_ = w;
-                height_ = h;
-            }
+        void SetColor(SDL_Color color) noexcept { color_ = color; }
+        void SetDimensions(float w, float h) noexcept
+        {
+            width_ = w;
+            height_ = h;
+        }
 
-            [[nodiscard]] SDL_Color GetColor() const noexcept { return color_; }
-            [[nodiscard]] float GetWidth() const noexcept { return width_; }
-            [[nodiscard]] float GetHeight() const noexcept { return height_; }
+        [[nodiscard]] SDL_Color GetColor() const noexcept { return color_; }
+        [[nodiscard]] float GetWidth() const noexcept { return width_; }
+        [[nodiscard]] float GetHeight() const noexcept { return height_; }
 
-        private:
-            SDL_Color color_;
-            float width_;
-            float height_;
+        [[nodiscard]] Engine::String GetTypeName() const override { return "SpriteComponent"; }
+
+    private:
+        SDL_Color color_;
+        float width_;
+        float height_;
     };
 }

--- a/GameEngine/GameEngine/GameEngine.vcxproj
+++ b/GameEngine/GameEngine/GameEngine.vcxproj
@@ -250,6 +250,7 @@
     <ClCompile Include="Engine\Source\Engine\Private\Gui\DefaultEngineGui.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\ContentBrowserPanel.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\SceneOutlinerPanel.cpp" />
+    <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\ActorInspectorPanel.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\StatsPanel.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiManager.cpp" />
     <ClCompile Include="Engine\Source\Engine\Private\Gui\GuiPanel.cpp" />
@@ -1802,6 +1803,7 @@
     <ClInclude Include="Engine\Source\Engine\Public\Gui\DefaultEngineGui.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\ContentBrowserPanel.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\SceneOutlinerPanel.h" />
+    <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\ActorInspectorPanel.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\StatsPanel.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Widgets\ActionTooltip.h" />
     <ClInclude Include="Engine\Source\Engine\Public\Gui\GuiManager.h" />

--- a/GameEngine/GameEngine/GameEngine.vcxproj.filters
+++ b/GameEngine/GameEngine/GameEngine.vcxproj.filters
@@ -136,6 +136,9 @@
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\SceneOutlinerPanel.cpp">
       <Filter>Source\Engine\Private\Gui</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\ActorInspectorPanel.cpp">
+      <Filter>Source\Engine\Private\Gui</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Source\Engine\Private\Gui\Panels\StatsPanel.cpp">
       <Filter>Source\Engine\Private\Gui</Filter>
     </ClCompile>
@@ -256,6 +259,9 @@
       <Filter>Source\Engine\Public\Gui</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\SceneOutlinerPanel.h">
+      <Filter>Source\Engine\Public\Gui</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\ActorInspectorPanel.h">
       <Filter>Source\Engine\Public\Gui</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Source\Engine\Public\Gui\Panels\StatsPanel.h">


### PR DESCRIPTION
## Summary
- add a Details inspector panel that shows the selected actor’s transform and components
- share actor selection state with the scene outliner and expose component metadata for display
- register the new panel in the default GUI setup and project files

## Testing
- not run (GUI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2563a65e083309f95875cf26900c3